### PR TITLE
Enforce minimum password strength

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
 	"require": {
 		"humanmade/stream": "dev-build",
 		"humanmade/two-factor": "dev-force-2fa",
-		"humanmade/require-login": "^1.0.0"
+		"humanmade/require-login": "^1.0.0",
+		"bjeavons/zxcvbn-php": "^0.4.0"
 	}
 }

--- a/docs/minimum-password-strength.md
+++ b/docs/minimum-password-strength.md
@@ -18,7 +18,7 @@ To disable the minimum password strength checks, set the `modules.security.minim
 
 ## Additional strength checks
 
-To add additional strength checks, a `hm-platform.security.passwords.is_weak` filter is provided. This filters the boolean `$is_weak` which can be set to `true` to reject a password.
+To add additional strength checks, a `hm_platform.security.passwords.is_weak` filter is provided. This filters the boolean `$is_weak` which can be set to `true` to reject a password.
 
 For example, to reject any passwords which contain the word "human":
 

--- a/docs/minimum-password-strength.md
+++ b/docs/minimum-password-strength.md
@@ -1,0 +1,35 @@
+# Minimum Password Strength
+
+To protect against brute force and dictionary attacks, Platform enforces a minimum password strength.
+
+Passwords are scored one of four possible scores:
+
+* Very Weak (score: 1)
+* Weak (score: 2)
+* Medium (score: 3)
+* Strong (score: 4)
+
+By default, passwords which score below 2 (i.e. Very Weak passwords) will be rejected.
+
+To change the minimum password strength, set the `modules.security.minimum-password-strength` setting to a different score (i.e. `3`).
+
+To disable the minimum password strength checks, set the `modules.security.minimum-password-strength` setting to `0`.
+
+
+## Additional strength checks
+
+To add additional strength checks, a `hm-platform.security.passwords.is_weak` filter is provided. This filters the boolean `$is_weak` which can be set to `true` to reject a password.
+
+For example, to reject any passwords which contain the word "human":
+
+```php
+add_filter( 'hm-platform.security.passwords.is_weak', function ( $is_weak, $password ) {
+	if ( strpos( $password, 'human' ) !== false ) {
+		return true;
+	}
+
+	return $is_weak;
+}, 10, 2 );
+```
+
+The filter receives other parameters which can be used for more dynamic checks; for example, you could require a higher password strength score for administrators.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -51,6 +51,10 @@ function on_plugins_loaded() {
 		add_filter( 'two_factor_providers', __NAMESPACE__ . '\\remove_2fa_dummy_provider' );
 		require_once ROOT_DIR . '/vendor/humanmade/two-factor/two-factor.php';
 	}
+
+	if ( ! empty( $config['minimum-password-strength'] ) && $config['minimum-password-strength'] > 0 ) {
+		Passwords\bootstrap();
+	}
 }
 
 function default_stream_network_options( $options ) : array {

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -99,7 +99,8 @@ function enforce_password_strength( $user_login, &$pass1, &$pass2 ) {
 
 	// Weak password. Clear both password fields to halt update, and add our
 	// custom error.
-	$pass1 = $pass2 = null;
+	$pass1 = null;
+	$pass2 = null;
 	add_action( 'user_profile_update_errors', __NAMESPACE__ . '\\add_strength_error' );
 }
 

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -34,7 +34,7 @@ function get_minimum_strength() {
 	 * - 3 = "Medium"
 	 * - 4 = "Strong"
 	 *
-	 * @param int $minimum_strength Minimum required strength. Defaults is 3.
+	 * @param int $minimum_strength Minimum required strength. Default is 3.
 	 */
 	return apply_filters( 'hm-platform.security.passwords.minimum_strength', $config['minimum-password-strength'] );
 }

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace HM\Platform\Security\Passwords;
+
+use function HM\Platform\get_config;
+use WP_Error;
+use ZxcvbnPhp\Zxcvbn;
+
+/**
+ * Bootstrap.
+ */
+function bootstrap() {
+	add_action( 'check_passwords', __NAMESPACE__ . '\\enforce_password_strength', 10, 3 );
+	add_action( 'admin_print_styles-user-edit.php', __NAMESPACE__ . '\\hide_weak_password_prompt' );
+	add_action( 'admin_print_styles-profile.php', __NAMESPACE__ . '\\hide_weak_password_prompt' );
+}
+
+/**
+ * Get minimum required strength for passwords.
+ *
+ * @return int
+ */
+function get_minimum_strength() {
+	$config = get_config()['modules']['security'];
+
+	/**
+	 * Filter the minimum required password strength.
+	 *
+	 * Filter the required strength for a password. These scores correspond to
+	 * the following UI strings:
+	 *
+	 * - 1 = "Very Weak"
+	 * - 2 = "Weak"
+	 * - 3 = "Medium"
+	 * - 4 = "Strong"
+	 *
+	 * @param int $minimum_strength Minimum required strength. Defaults is 3.
+	 */
+	return apply_filters( 'hm-platform.security.passwords.minimum_strength', $config['minimum-password-strength'] );
+}
+
+/**
+ * Enforce minimum password strength during password check.
+ *
+ * @param string $user_login User login slug
+ * @param string $pass1 First password input field
+ * @param string $pass2 Second password input field
+ */
+function enforce_password_strength( $user_login, &$pass1, &$pass2 ) {
+	if ( empty( $pass1 ) || $pass1 !== $pass2 ) {
+		// Handled by WordPress, skip.
+		return;
+	}
+
+	// Add extra data to password strength checks.
+	// (Matches list in password-strength-meter.js)
+	$user = get_user_by( 'login', $user_login );
+	$extra_data = [
+		$user->user_login,
+		$user->first_name,
+		$user->last_name,
+		$user->nickname,
+		$user->display_name,
+		$user->email,
+		$user->url,
+		$user->description,
+	];
+
+	$checker = new Zxcvbn();
+	$results = $checker->passwordStrength( $pass1, $extra_data );
+	$strength = $results['score'];
+
+	$is_weak = $strength < get_minimum_strength();
+
+	/**
+	 * Filter whether a password is considered weak.
+	 *
+	 * @param boolean $is_weak True if the password is considered weak, and should be rejected. False to allow the password.
+	 * @param string $pass1 Supplied password.
+	 * @param WP_User $user User the password is being changed for.
+	 * @param array $results Results from Zxcvbn's check.
+	 */
+	$is_weak = apply_filters( 'hm-platform.security.passwords.is_weak', $is_weak, $pass1, $user, $results );
+	if ( ! $is_weak ) {
+		// Password is strong enough, allow it.
+		return;
+	}
+
+	// Weak password. Clear both password fields to halt update, and add our
+	// custom error.
+	$pass1 = $pass2 = null;
+	add_action( 'user_profile_update_errors', __NAMESPACE__ . '\\add_strength_error' );
+}
+
+/**
+ * Add password strength error to the error list.
+ *
+ * Used as a callback inside enforce_password_strength()
+ *
+ * @param WP_Error $errors Error object to add error to.
+ */
+function add_strength_error( WP_Error $errors ) {
+	$errors->add( 'pass', __( '<strong>ERROR</strong>: Please use a stronger password.' ), array( 'form-field' => 'pass1' ) );
+}
+
+/**
+ * Hide "confirm use of weak password" prompt if minimum strength is set.
+ */
+function hide_weak_password_prompt() {
+	// Are we allowing weak passwords?
+	if ( get_minimum_strength() < 1 ) {
+		return;
+	}
+
+	echo '<style>.pw-weak { display: none !important; }</style>';
+}

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -68,9 +68,7 @@ function enforce_password_strength( $user_login, &$pass1, &$pass2 ) {
 
 	$checker = new Zxcvbn();
 	$results = $checker->passwordStrength( $pass1, $extra_data );
-	$strength = $results['score'];
-
-	$is_weak = $strength < get_minimum_strength();
+	$is_weak = $results['score'] < get_minimum_strength();
 
 	/**
 	 * Filter whether a password is considered weak.

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -111,7 +111,7 @@ function enforce_password_strength( $user_login, &$pass1, &$pass2 ) {
  * @param WP_Error $errors Error object to add error to.
  */
 function add_strength_error( WP_Error $errors ) {
-	$errors->add( 'pass', __( '<strong>ERROR</strong>: Please use a stronger password.' ), array( 'form-field' => 'pass1' ) );
+	$errors->add( 'pass', __( '<strong>ERROR</strong>: Please use a stronger password.', 'hm-platform' ), [ 'form-field' => 'pass1' ] );
 }
 
 /**

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -18,7 +18,15 @@ function bootstrap() {
 /**
  * Get minimum required strength for passwords.
  *
- * @return int
+ * Gets the minimum required "score" for passwords. The score corresponds to
+ * the following UI strings:
+ *
+ * - 1 = "Very Weak"
+ * - 2 = "Weak"
+ * - 3 = "Medium"
+ * - 4 = "Strong"
+ *
+ * @return int Minimum required strength
  */
 function get_minimum_strength() : int {
 	$config = get_config()['modules']['security'];

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -44,7 +44,7 @@ function get_minimum_strength() : int {
 	 *
 	 * @param int $minimum_strength Minimum required strength. Default is 3.
 	 */
-	return apply_filters( 'hm-platform.security.passwords.minimum_strength', $config['minimum-password-strength'] );
+	return apply_filters( 'hm_platform.security.passwords.minimum_strength', $config['minimum-password-strength'] );
 }
 
 /**
@@ -91,7 +91,7 @@ function enforce_password_strength( $user_login, &$pass1, &$pass2 ) {
 	 * @param WP_User $user User the password is being changed for.
 	 * @param array $results Results from Zxcvbn's check.
 	 */
-	$is_weak = apply_filters( 'hm-platform.security.passwords.is_weak', $is_weak, $pass1, $user, $results );
+	$is_weak = apply_filters( 'hm_platform.security.passwords.is_weak', $is_weak, $pass1, $user, $results );
 	if ( ! $is_weak ) {
 		// Password is strong enough, allow it.
 		return;

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -42,7 +42,7 @@ function get_minimum_strength() : int {
 	 * - 3 = "Medium"
 	 * - 4 = "Strong"
 	 *
-	 * @param int $minimum_strength Minimum required strength. Default is 3.
+	 * @param int $minimum_strength Minimum required strength. Default is 2.
 	 */
 	return apply_filters( 'hm_platform.security.passwords.minimum_strength', $config['minimum-password-strength'] );
 }

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -63,6 +63,11 @@ function enforce_password_strength( $user_login, &$pass1, &$pass2 ) {
 	// Add extra data to password strength checks.
 	// (Matches list in password-strength-meter.js)
 	$user = get_user_by( 'login', $user_login );
+	if ( empty( $user ) ) {
+		// No user found.
+		return;
+	}
+
 	$extra_data = [
 		$user->user_login,
 		$user->first_name,

--- a/inc/passwords/namespace.php
+++ b/inc/passwords/namespace.php
@@ -20,7 +20,7 @@ function bootstrap() {
  *
  * @return int
  */
-function get_minimum_strength() {
+function get_minimum_strength() : int {
 	$config = get_config()['modules']['security'];
 
 	/**

--- a/load.php
+++ b/load.php
@@ -5,13 +5,15 @@ namespace HM\Platform\Security;
 use HM\Platform;
 
 require_once __DIR__ . '/inc/namespace.php';
+require_once __DIR__ . '/inc/passwords/namespace.php';
 
 add_action( 'hm-platform.modules.init', function () {
 	$default_settings = [
-		'enabled'                 => true,
-		'require-login'           => ! in_array( Platform\get_environment_type(), [ 'production', 'local' ], true ),
-		'audit-log'               => true,
-		'2-factor-authentication' => true,
+		'enabled'                   => true,
+		'require-login'             => ! in_array( Platform\get_environment_type(), [ 'production', 'local' ], true ),
+		'audit-log'                 => true,
+		'2-factor-authentication'   => true,
+		'minimum-password-strength' => 3,
 	];
 	Platform\register_module( 'security', __DIR__, 'Security', $default_settings, __NAMESPACE__ . '\\bootstrap' );
 } );

--- a/load.php
+++ b/load.php
@@ -13,7 +13,7 @@ add_action( 'hm-platform.modules.init', function () {
 		'require-login'             => ! in_array( Platform\get_environment_type(), [ 'production', 'local' ], true ),
 		'audit-log'                 => true,
 		'2-factor-authentication'   => true,
-		'minimum-password-strength' => 3,
+		'minimum-password-strength' => 2,
 	];
 	Platform\register_module( 'security', __DIR__, 'Security', $default_settings, __NAMESPACE__ . '\\bootstrap' );
 } );


### PR DESCRIPTION
Uses zxcvbn on the backend to test password strength. Note that frontend strength may not match, as it's not the exact same test on the frontend as the backend.

For now, I've set the minimum strength to 2 ("Weak") so only "Very Weak" passwords will be rejected. Additionally, it hides the "confirm use of weak password" prompt, so the submit button will be disabled.

Adds the `minimum-password-strength` config option for the security module; set to 0 or false to disable this functionality. Also adds filters to allow additional checks or dynamic behaviour depending on role.

Fixes #2.