### PR TITLE
Add main docs page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Security
+
+The security module provides high-level security focused features to the Platform. This module is concerned with security features such as Multi Factor Authentication, Password Strength Rules, Audit Logging etc.


### PR DESCRIPTION
I don't really know what we want here longer term, but we shoud have _something_ to not get a 404 on the doc's homepage.